### PR TITLE
'Trimmando' o atributo $path da ObjectManager

### DIFF
--- a/src/RockEinstein/FlowBinair/ObjectManager.php
+++ b/src/RockEinstein/FlowBinair/ObjectManager.php
@@ -14,7 +14,7 @@ class ObjectManager {
     private $method;
 
     public function __construct($path) {
-        $this->path = $path;
+        $this->path = trim($path);
 
         return $this;
     }


### PR DESCRIPTION
Assim ao escrever as regras é possível usar múltiplas linhas, por ex.:

<pre>
  <code>
"01" => "{$namespace}{$context}->ruleOne
           && {$namespace}{$context}->ruleTwo
           && {$namespace}{$context}->hasThree"
  </code>
</pre>
